### PR TITLE
Fix cleanAll.sh. Add -f to rm to not get errors when nothing is removed.

### DIFF
--- a/examples/cleanAll.sh
+++ b/examples/cleanAll.sh
@@ -20,7 +20,7 @@ rm -rf auth*
 cd ../../
 
 cd $AUTH_PROPERTIES_DIR
-rm *.properties
+rm -f *.properties
 cd ../../
 
 cd $ENTITY_CREDS_DIR


### PR DESCRIPTION
Add `-f` to `rm` commands to not get this error, when `./cleanAll.sh` was already executed.

`rm: cannot remove '*.properties': No such file or directory`