### PR TITLE
Support different AES encryption modes with crypto spec

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -58,3 +58,30 @@ For the following instructions, we use $ROOT to indicate the root directory of t
 ![Image of Auth101 Config](https://raw.githubusercontent.com/iotauth/iotauth/master/examples/figures/auth101_intellij_config.png)
 
 ![Image of Auth102 Config](https://raw.githubusercontent.com/iotauth/iotauth/master/examples/figures/auth102_intellij_config.png)
+
+
+# Using VSCode
+
+* Install the [Maven for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-maven) and [Extension Pack for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-pack) extensions.
+
+* Get to the `Explorer` (Ctrl+Shift+E), and find the `Maven` tab. Go to the `auth-server/Lifecycle`, and push the play button on `clean` and `install`.
+
+* Add the below configuration to `launch.json`.
+```
+        {
+            "name": "auth",
+            "type": "java",
+            "request": "launch",
+            "mainClass": "org.iot.auth.AuthServer",
+            "args": [
+                "-p",
+                "../properties/exampleAuth101.properties"
+            ],
+            "cwd": "${workspaceFolder}/auth/auth-server",
+            "vmArgs": "-Djava.version=17",
+            "javaHome": "/usr/lib/jvm/java-17-openjdk-amd64/bin/java"
+        },
+```
+
+* Also, add `"java.jdt.ls.java.home": "/usr/lib/jvm/java-17-openjdk-amd64/bin/java"` to `settings.json`.
+* Then, push the `F5`.

--- a/auth/auth-server/src/main/java/org/iot/auth/server/EntityConnectionHandler.java
+++ b/auth/auth-server/src/main/java/org/iot/auth/server/EntityConnectionHandler.java
@@ -343,6 +343,11 @@ public abstract class EntityConnectionHandler {
             sendAuthAlert(AuthAlertCode.INVALID_SESSION_KEY_REQ);
             close();
         }
+        catch (RuntimeException e) {
+            getLogger().info("RuntimeException: " + e.getMessage());
+            sendAuthAlert(AuthAlertCode.INVALID_SESSION_KEY_REQ);
+            close();
+        }
     }
 
     /**

--- a/auth/library/src/main/java/org/iot/auth/crypto/SymmetricKeyCryptoSpec.java
+++ b/auth/library/src/main/java/org/iot/auth/crypto/SymmetricKeyCryptoSpec.java
@@ -178,6 +178,9 @@ public class SymmetricKeyCryptoSpec extends CryptoSpec {
         else if (jsCryptoAlgo.equals("AES-128-CTR")) {
             return new CryptoAlgoKeySize("AES/CTR/NoPadding", 16);
         }
+        else if (jsCryptoAlgo.equals("AES-128-GCM")) {
+            return new CryptoAlgoKeySize("AES/GCM/PKCS5Padding", 16);
+        }
         else if (jsCryptoAlgo.equals("SHA256")) {
             return new CryptoAlgoKeySize("HmacSHA256");
         }

--- a/auth/library/src/main/java/org/iot/auth/crypto/SymmetricKeyCryptoSpec.java
+++ b/auth/library/src/main/java/org/iot/auth/crypto/SymmetricKeyCryptoSpec.java
@@ -115,6 +115,11 @@ public class SymmetricKeyCryptoSpec extends CryptoSpec {
             }
             // 128 bits -> 16 bytes
         }
+        else if (cryptoAlgo.equals("AES/CTR/PKCS5Padding")) {
+            if (keySize == 16) {
+                return new String("AES-128-CTR");
+            }
+        }
         else if (cryptoAlgo.equals("HmacSHA256")) {
             return new String("SHA256");
         }
@@ -163,12 +168,15 @@ public class SymmetricKeyCryptoSpec extends CryptoSpec {
             return new CryptoAlgoKeySize("AES/CBC/PKCS5Padding", 16);
         }
         else if (jsCryptoAlgo.equals("AES-192-CBC")) {
-            // 128 bits -> 16 bytes
+            // 192 bits -> 24 bytes
             return new CryptoAlgoKeySize("AES/CBC/PKCS5Padding", 24);
         }
         else if (jsCryptoAlgo.equals("AES-256-CBC")) {
-            // 128 bits -> 16 bytes
+            // 256 bits -> 32 bytes
             return new CryptoAlgoKeySize("AES/CBC/PKCS5Padding", 32);
+        }
+        else if (jsCryptoAlgo.equals("AES-128-CTR")) {
+            return new CryptoAlgoKeySize("AES/CTR/PKCS5Padding", 16);
         }
         else if (jsCryptoAlgo.equals("SHA256")) {
             return new CryptoAlgoKeySize("HmacSHA256");

--- a/auth/library/src/main/java/org/iot/auth/crypto/SymmetricKeyCryptoSpec.java
+++ b/auth/library/src/main/java/org/iot/auth/crypto/SymmetricKeyCryptoSpec.java
@@ -19,6 +19,7 @@ import org.json.simple.JSONObject;
 
 /**
  * A class for symmetric key cryptography specifications
+ * 
  * @author Hokeun Kim
  */
 public class SymmetricKeyCryptoSpec extends CryptoSpec {
@@ -38,6 +39,7 @@ public class SymmetricKeyCryptoSpec extends CryptoSpec {
 
     /**
      * Constructor for symmetric crypto spec that uses MAC only.
+     * 
      * @param macAlgorithm The name of MAC algorithm
      */
     public SymmetricKeyCryptoSpec(String macAlgorithm) {
@@ -49,8 +51,8 @@ public class SymmetricKeyCryptoSpec extends CryptoSpec {
     }
 
     public static SymmetricKeyCryptoSpec fromJSONObject(JSONObject jsonObject) {
-        CryptoAlgoKeySize cipherAlgoKeySize = fromJSCryptoAlgo((String)jsonObject.get(key.cipher.toString()));
-        CryptoAlgoKeySize hashAlgoKeySize = fromJSCryptoAlgo((String)jsonObject.get(key.mac.toString()));
+        CryptoAlgoKeySize cipherAlgoKeySize = fromJSCryptoAlgo((String) jsonObject.get(key.cipher.toString()));
+        CryptoAlgoKeySize hashAlgoKeySize = fromJSCryptoAlgo((String) jsonObject.get(key.mac.toString()));
 
         return new SymmetricKeyCryptoSpec(cipherAlgoKeySize.getCryptoAlgo(), cipherAlgoKeySize.getKeySize(),
                 hashAlgoKeySize.getCryptoAlgo());
@@ -69,15 +71,19 @@ public class SymmetricKeyCryptoSpec extends CryptoSpec {
     public String toSpecString() {
         return toJavaScriptSpecString(cipherAlgorithm, cipherKeySize) + ":" + toJavaScriptSpecString(macAlgorithm, -1);
     }
+
     public String getCipherAlgorithm() {
         return cipherAlgorithm;
     }
+
     public int getCipherKeySize() {
         return cipherKeySize;
     }
+
     public String getMacAlgorithm() {
         return macAlgorithm;
     }
+
     public int getMacKeySize() {
         return macKeySize;
     }
@@ -91,7 +97,7 @@ public class SymmetricKeyCryptoSpec extends CryptoSpec {
     }
 
     public String toString() {
-            return "Cipher: " + cipherAlgorithm + "\tCipherKeySize: " + cipherKeySize + "\tMAC Algorithm: " + macAlgorithm;
+        return "Cipher: " + cipherAlgorithm + "\tCipherKeySize: " + cipherKeySize + "\tMAC Algorithm: " + macAlgorithm;
     }
 
     private String cipherAlgorithm;
@@ -102,25 +108,24 @@ public class SymmetricKeyCryptoSpec extends CryptoSpec {
     private static String toJavaScriptSpecString(String cryptoAlgo, int keySize) {
         if (cryptoAlgo.equals("")) {
             return new String("");
-        }
-        else if (cryptoAlgo.equals("AES/CBC/PKCS5Padding")) {
+        } else if (cryptoAlgo.equals("AES/CBC/PKCS5Padding")) {
             if (keySize == 16) {
                 return new String("AES-128-CBC");
-            }
-            else if (keySize == 24) {
+            } else if (keySize == 24) {
                 return new String("AES-192-CBC");
-            }
-            else if (keySize == 32) {
+            } else if (keySize == 32) {
                 return new String("AES-256-CBC");
             }
             // 128 bits -> 16 bytes
-        }
-        else if (cryptoAlgo.equals("AES/CTR/NoPadding")) {
+        } else if (cryptoAlgo.equals("AES/CTR/NoPadding")) {
             if (keySize == 16) {
                 return new String("AES-128-CTR");
             }
-        }
-        else if (cryptoAlgo.equals("HmacSHA256")) {
+        } else if (cryptoAlgo.equals("AES/GCM/NoPadding")) {
+            if (keySize == 16) {
+                return new String("AES-128-GCM");
+            }
+        } else if (cryptoAlgo.equals("HmacSHA256")) {
             return new String("SHA256");
         }
         throw new IllegalArgumentException("No such crypto algorithm: " + cryptoAlgo + ", keySize:" + keySize);
@@ -129,32 +134,35 @@ public class SymmetricKeyCryptoSpec extends CryptoSpec {
     private static int getMacAlgoKeySize(String macAlgo) {
         if (macAlgo.equals("HmacSHA256")) {
             return 32;
-        }
-        else {
+        } else {
             throw new IllegalArgumentException("No such MAC algorithm: " + macAlgo);
         }
     }
-
 
     private static class CryptoAlgoKeySize {
         public CryptoAlgoKeySize(String cipherAlgo, int keySize) {
             this.cipherAlgo = cipherAlgo;
             this.keySize = keySize;
         }
+
         public CryptoAlgoKeySize(String cipherAlgo) {
             this.cipherAlgo = cipherAlgo;
             this.keySize = -1;
         }
+
         public CryptoAlgoKeySize() {
             this.cipherAlgo = "";
             this.keySize = 0;
         }
+
         public String getCryptoAlgo() {
             return cipherAlgo;
         }
+
         public int getKeySize() {
             return keySize;
         }
+
         private String cipherAlgo;
         private int keySize;
     }
@@ -162,26 +170,20 @@ public class SymmetricKeyCryptoSpec extends CryptoSpec {
     private static CryptoAlgoKeySize fromJSCryptoAlgo(String jsCryptoAlgo) {
         if (jsCryptoAlgo.equals("")) {
             return new CryptoAlgoKeySize();
-        }
-        else if (jsCryptoAlgo.equals("AES-128-CBC")) {
+        } else if (jsCryptoAlgo.equals("AES-128-CBC")) {
             // 128 bits -> 16 bytes
             return new CryptoAlgoKeySize("AES/CBC/PKCS5Padding", 16);
-        }
-        else if (jsCryptoAlgo.equals("AES-192-CBC")) {
+        } else if (jsCryptoAlgo.equals("AES-192-CBC")) {
             // 192 bits -> 24 bytes
             return new CryptoAlgoKeySize("AES/CBC/PKCS5Padding", 24);
-        }
-        else if (jsCryptoAlgo.equals("AES-256-CBC")) {
+        } else if (jsCryptoAlgo.equals("AES-256-CBC")) {
             // 256 bits -> 32 bytes
             return new CryptoAlgoKeySize("AES/CBC/PKCS5Padding", 32);
-        }
-        else if (jsCryptoAlgo.equals("AES-128-CTR")) {
+        } else if (jsCryptoAlgo.equals("AES-128-CTR")) {
             return new CryptoAlgoKeySize("AES/CTR/NoPadding", 16);
-        }
-        else if (jsCryptoAlgo.equals("AES-128-GCM")) {
-            return new CryptoAlgoKeySize("AES/GCM/PKCS5Padding", 16);
-        }
-        else if (jsCryptoAlgo.equals("SHA256")) {
+        } else if (jsCryptoAlgo.equals("AES-128-GCM")) {
+            return new CryptoAlgoKeySize("AES/GCM/NoPadding", 16);
+        } else if (jsCryptoAlgo.equals("SHA256")) {
             return new CryptoAlgoKeySize("HmacSHA256");
         }
         throw new IllegalArgumentException("No such JS crypto algorithm: " + jsCryptoAlgo);

--- a/auth/library/src/main/java/org/iot/auth/crypto/SymmetricKeyCryptoSpec.java
+++ b/auth/library/src/main/java/org/iot/auth/crypto/SymmetricKeyCryptoSpec.java
@@ -19,7 +19,6 @@ import org.json.simple.JSONObject;
 
 /**
  * A class for symmetric key cryptography specifications
- * 
  * @author Hokeun Kim
  */
 public class SymmetricKeyCryptoSpec extends CryptoSpec {
@@ -39,7 +38,6 @@ public class SymmetricKeyCryptoSpec extends CryptoSpec {
 
     /**
      * Constructor for symmetric crypto spec that uses MAC only.
-     * 
      * @param macAlgorithm The name of MAC algorithm
      */
     public SymmetricKeyCryptoSpec(String macAlgorithm) {
@@ -51,8 +49,8 @@ public class SymmetricKeyCryptoSpec extends CryptoSpec {
     }
 
     public static SymmetricKeyCryptoSpec fromJSONObject(JSONObject jsonObject) {
-        CryptoAlgoKeySize cipherAlgoKeySize = fromJSCryptoAlgo((String) jsonObject.get(key.cipher.toString()));
-        CryptoAlgoKeySize hashAlgoKeySize = fromJSCryptoAlgo((String) jsonObject.get(key.mac.toString()));
+        CryptoAlgoKeySize cipherAlgoKeySize = fromJSCryptoAlgo((String)jsonObject.get(key.cipher.toString()));
+        CryptoAlgoKeySize hashAlgoKeySize = fromJSCryptoAlgo((String)jsonObject.get(key.mac.toString()));
 
         return new SymmetricKeyCryptoSpec(cipherAlgoKeySize.getCryptoAlgo(), cipherAlgoKeySize.getKeySize(),
                 hashAlgoKeySize.getCryptoAlgo());
@@ -71,19 +69,15 @@ public class SymmetricKeyCryptoSpec extends CryptoSpec {
     public String toSpecString() {
         return toJavaScriptSpecString(cipherAlgorithm, cipherKeySize) + ":" + toJavaScriptSpecString(macAlgorithm, -1);
     }
-
     public String getCipherAlgorithm() {
         return cipherAlgorithm;
     }
-
     public int getCipherKeySize() {
         return cipherKeySize;
     }
-
     public String getMacAlgorithm() {
         return macAlgorithm;
     }
-
     public int getMacKeySize() {
         return macKeySize;
     }
@@ -97,7 +91,7 @@ public class SymmetricKeyCryptoSpec extends CryptoSpec {
     }
 
     public String toString() {
-        return "Cipher: " + cipherAlgorithm + "\tCipherKeySize: " + cipherKeySize + "\tMAC Algorithm: " + macAlgorithm;
+            return "Cipher: " + cipherAlgorithm + "\tCipherKeySize: " + cipherKeySize + "\tMAC Algorithm: " + macAlgorithm;
     }
 
     private String cipherAlgorithm;
@@ -108,24 +102,30 @@ public class SymmetricKeyCryptoSpec extends CryptoSpec {
     private static String toJavaScriptSpecString(String cryptoAlgo, int keySize) {
         if (cryptoAlgo.equals("")) {
             return new String("");
-        } else if (cryptoAlgo.equals("AES/CBC/PKCS5Padding")) {
+        }
+        else if (cryptoAlgo.equals("AES/CBC/PKCS5Padding")) {
             if (keySize == 16) {
                 return new String("AES-128-CBC");
-            } else if (keySize == 24) {
+            }
+            else if (keySize == 24) {
                 return new String("AES-192-CBC");
-            } else if (keySize == 32) {
+            }
+            else if (keySize == 32) {
                 return new String("AES-256-CBC");
             }
             // 128 bits -> 16 bytes
-        } else if (cryptoAlgo.equals("AES/CTR/NoPadding")) {
+        }
+        else if (cryptoAlgo.equals("AES/CTR/NoPadding")) {
             if (keySize == 16) {
                 return new String("AES-128-CTR");
             }
-        } else if (cryptoAlgo.equals("AES/GCM/NoPadding")) {
+        }
+        else if (cryptoAlgo.equals("AES/GCM/NoPadding")) {
             if (keySize == 16) {
                 return new String("AES-128-GCM");
             }
-        } else if (cryptoAlgo.equals("HmacSHA256")) {
+        }
+        else if (cryptoAlgo.equals("HmacSHA256")) {
             return new String("SHA256");
         }
         throw new IllegalArgumentException("No such crypto algorithm: " + cryptoAlgo + ", keySize:" + keySize);
@@ -134,35 +134,32 @@ public class SymmetricKeyCryptoSpec extends CryptoSpec {
     private static int getMacAlgoKeySize(String macAlgo) {
         if (macAlgo.equals("HmacSHA256")) {
             return 32;
-        } else {
+        }
+        else {
             throw new IllegalArgumentException("No such MAC algorithm: " + macAlgo);
         }
     }
+
 
     private static class CryptoAlgoKeySize {
         public CryptoAlgoKeySize(String cipherAlgo, int keySize) {
             this.cipherAlgo = cipherAlgo;
             this.keySize = keySize;
         }
-
         public CryptoAlgoKeySize(String cipherAlgo) {
             this.cipherAlgo = cipherAlgo;
             this.keySize = -1;
         }
-
         public CryptoAlgoKeySize() {
             this.cipherAlgo = "";
             this.keySize = 0;
         }
-
         public String getCryptoAlgo() {
             return cipherAlgo;
         }
-
         public int getKeySize() {
             return keySize;
         }
-
         private String cipherAlgo;
         private int keySize;
     }
@@ -170,20 +167,26 @@ public class SymmetricKeyCryptoSpec extends CryptoSpec {
     private static CryptoAlgoKeySize fromJSCryptoAlgo(String jsCryptoAlgo) {
         if (jsCryptoAlgo.equals("")) {
             return new CryptoAlgoKeySize();
-        } else if (jsCryptoAlgo.equals("AES-128-CBC")) {
+        }
+        else if (jsCryptoAlgo.equals("AES-128-CBC")) {
             // 128 bits -> 16 bytes
             return new CryptoAlgoKeySize("AES/CBC/PKCS5Padding", 16);
-        } else if (jsCryptoAlgo.equals("AES-192-CBC")) {
-            // 192 bits -> 24 bytes
+        }
+        else if (jsCryptoAlgo.equals("AES-192-CBC")) {
+            // 128 bits -> 16 bytes
             return new CryptoAlgoKeySize("AES/CBC/PKCS5Padding", 24);
-        } else if (jsCryptoAlgo.equals("AES-256-CBC")) {
-            // 256 bits -> 32 bytes
+        }
+        else if (jsCryptoAlgo.equals("AES-256-CBC")) {
+            // 128 bits -> 16 bytes
             return new CryptoAlgoKeySize("AES/CBC/PKCS5Padding", 32);
-        } else if (jsCryptoAlgo.equals("AES-128-CTR")) {
+        } 
+        else if (jsCryptoAlgo.equals("AES-128-CTR")) {
             return new CryptoAlgoKeySize("AES/CTR/NoPadding", 16);
-        } else if (jsCryptoAlgo.equals("AES-128-GCM")) {
+        } 
+        else if (jsCryptoAlgo.equals("AES-128-GCM")) {
             return new CryptoAlgoKeySize("AES/GCM/NoPadding", 16);
-        } else if (jsCryptoAlgo.equals("SHA256")) {
+        }
+        else if (jsCryptoAlgo.equals("SHA256")) {
             return new CryptoAlgoKeySize("HmacSHA256");
         }
         throw new IllegalArgumentException("No such JS crypto algorithm: " + jsCryptoAlgo);

--- a/auth/library/src/main/java/org/iot/auth/crypto/SymmetricKeyCryptoSpec.java
+++ b/auth/library/src/main/java/org/iot/auth/crypto/SymmetricKeyCryptoSpec.java
@@ -115,7 +115,7 @@ public class SymmetricKeyCryptoSpec extends CryptoSpec {
             }
             // 128 bits -> 16 bytes
         }
-        else if (cryptoAlgo.equals("AES/CTR/PKCS5Padding")) {
+        else if (cryptoAlgo.equals("AES/CTR/NoPadding")) {
             if (keySize == 16) {
                 return new String("AES-128-CTR");
             }
@@ -176,7 +176,7 @@ public class SymmetricKeyCryptoSpec extends CryptoSpec {
             return new CryptoAlgoKeySize("AES/CBC/PKCS5Padding", 32);
         }
         else if (jsCryptoAlgo.equals("AES-128-CTR")) {
-            return new CryptoAlgoKeySize("AES/CTR/PKCS5Padding", 16);
+            return new CryptoAlgoKeySize("AES/CTR/NoPadding", 16);
         }
         else if (jsCryptoAlgo.equals("SHA256")) {
             return new CryptoAlgoKeySize("HmacSHA256");

--- a/entity/node/package.json
+++ b/entity/node/package.json
@@ -9,7 +9,6 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "mqtt": "*",
-    "sleep": "*",
     "pem": "*",
     "int64-buffer": "*"
   },

--- a/entity/python/entity_server.py
+++ b/entity/python/entity_server.py
@@ -354,7 +354,7 @@ def auth_socket_connect(config_dict: dict) -> socket.socket:
     """
     client_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     Host = config_dict["auth_ip_address"]
-    Port = int(config_dict["auth_port_number"])
+    Port = config_dict["auth_port_number"]
     client_sock.connect((Host, Port))
     return client_sock
 

--- a/examples/authConfigGenerator.js
+++ b/examples/authConfigGenerator.js
@@ -167,7 +167,7 @@ function addUploadDownloadlPolicy(list, requestingGroup, target) {
     });    
 }
 // generate client policy tables
-function addComputeCompactionPolicy(list, requestingGroup, target, absoluteValidity, relativeValidity) {
+function addComputeCompactionCTRPolicy(list, requestingGroup, target, absoluteValidity, relativeValidity) {
     list.push({
         RequestingGroup: requestingGroup,
         TargetType: 'Group',
@@ -251,7 +251,7 @@ function generateCommunicationPolicyTables() {
     addServerClientPolicy(policyList, 'TeamA', 'FileManager', '1*day', '2*hour');
     addServerClientPolicy(policyList, 'TeamB', 'FileManager', '1*day', '2*hour');
     addServerClientPolicy(policyList, 'TeamC', 'FileManager', '1*day', '2*hour');
-    addComputeCompactionPolicy(policyList, 'ComputeNodes', 'CompactionNodes', '1*day', '2*hour');
+    addComputeCompactionCTRPolicy(policyList, 'ComputeNodesCTR', 'CompactionNodesCTR', '1*day', '2*hour');
     addComputeCompactionGCMPolicy(policyList, 'ComputeNodesGCM', 'CompactionNodesGCM', '1*day', '2*hour');
     addComputeCompactionCBCPolicy(policyList, 'ComputeNodesCBC', 'CompactionNodesCBC', '1*day', '2*hour');
     for (var i = 0; i < authList.length; i++) {

--- a/examples/authConfigGenerator.js
+++ b/examples/authConfigGenerator.js
@@ -188,6 +188,50 @@ function addComputeCompactionPolicy(list, requestingGroup, target, absoluteValid
     });
 }
 
+// generate client policy tables
+function addComputeCompactionGCMPolicy(list, requestingGroup, target, absoluteValidity, relativeValidity) {
+    list.push({
+        RequestingGroup: requestingGroup,
+        TargetType: 'Group',
+        Target: target,
+        MaxNumSessionKeyOwners: 2,
+        SessionCryptoSpec: 'AES-128-GCM:SHA256',
+        AbsoluteValidity: absoluteValidity,
+        RelativeValidity: relativeValidity
+    });
+    list.push({
+        RequestingGroup: target,
+        TargetType: 'Group',
+        Target: requestingGroup,
+        MaxNumSessionKeyOwners: 2,
+        SessionCryptoSpec: 'AES-128-GCM:SHA256',
+        AbsoluteValidity: absoluteValidity,
+        RelativeValidity: relativeValidity
+    });
+}
+
+// generate client policy tables
+function addComputeCompactionCBCPolicy(list, requestingGroup, target, absoluteValidity, relativeValidity) {
+    list.push({
+        RequestingGroup: requestingGroup,
+        TargetType: 'Group',
+        Target: target,
+        MaxNumSessionKeyOwners: 2,
+        SessionCryptoSpec: 'AES-128-CBC:SHA256',
+        AbsoluteValidity: absoluteValidity,
+        RelativeValidity: relativeValidity
+    });
+    list.push({
+        RequestingGroup: target,
+        TargetType: 'Group',
+        Target: requestingGroup,
+        MaxNumSessionKeyOwners: 2,
+        SessionCryptoSpec: 'AES-128-CBC:SHA256',
+        AbsoluteValidity: absoluteValidity,
+        RelativeValidity: relativeValidity
+    });
+}
+
 function generateCommunicationPolicyTables() {
     var policyList = [];
     addServerClientPolicy(policyList, 'Clients', 'Servers', '1*day', '2*hour');
@@ -208,6 +252,8 @@ function generateCommunicationPolicyTables() {
     addServerClientPolicy(policyList, 'TeamB', 'FileManager', '1*day', '2*hour');
     addServerClientPolicy(policyList, 'TeamC', 'FileManager', '1*day', '2*hour');
     addComputeCompactionPolicy(policyList, 'ComputeNodes', 'CompactionNodes', '1*day', '2*hour');
+    addComputeCompactionGCMPolicy(policyList, 'ComputeNodesGCM', 'CompactionNodesGCM', '1*day', '2*hour');
+    addComputeCompactionCBCPolicy(policyList, 'ComputeNodesCBC', 'CompactionNodesCBC', '1*day', '2*hour');
     for (var i = 0; i < authList.length; i++) {
         var auth = authList[i];
         var configFilePath = getAuthConfigDir(auth.id) + 'Auth' + auth.id + 'CommunicationPolicyTable.config';

--- a/examples/authConfigGenerator.js
+++ b/examples/authConfigGenerator.js
@@ -166,6 +166,27 @@ function addUploadDownloadlPolicy(list, requestingGroup, target) {
         RelativeValidity: '365*day'
     });    
 }
+// generate client policy tables
+function addComputeCompactionPolicy(list, requestingGroup, target, absoluteValidity, relativeValidity) {
+    list.push({
+        RequestingGroup: requestingGroup,
+        TargetType: 'Group',
+        Target: target,
+        MaxNumSessionKeyOwners: 2,
+        SessionCryptoSpec: 'AES-128-CTR:SHA256',
+        AbsoluteValidity: absoluteValidity,
+        RelativeValidity: relativeValidity
+    });
+    list.push({
+        RequestingGroup: target,
+        TargetType: 'Group',
+        Target: requestingGroup,
+        MaxNumSessionKeyOwners: 2,
+        SessionCryptoSpec: 'AES-128-CTR:SHA256',
+        AbsoluteValidity: absoluteValidity,
+        RelativeValidity: relativeValidity
+    });
+}
 
 function generateCommunicationPolicyTables() {
     var policyList = [];
@@ -186,6 +207,7 @@ function generateCommunicationPolicyTables() {
     addServerClientPolicy(policyList, 'TeamA', 'FileManager', '1*day', '2*hour');
     addServerClientPolicy(policyList, 'TeamB', 'FileManager', '1*day', '2*hour');
     addServerClientPolicy(policyList, 'TeamC', 'FileManager', '1*day', '2*hour');
+    addComputeCompactionPolicy(policyList, 'ComputeNodes', 'CompactionNodes', '1*day', '2*hour');
     for (var i = 0; i < authList.length; i++) {
         var auth = authList[i];
         var configFilePath = getAuthConfigDir(auth.id) + 'Auth' + auth.id + 'CommunicationPolicyTable.config';

--- a/examples/authConfigGenerator.js
+++ b/examples/authConfigGenerator.js
@@ -60,7 +60,7 @@ function getRegisteredEntity(entity) {
         UsePermanentDistKey: entity.usePermanentDistKey,
         MaxSessionKeysPerRequest: entity.maxSessionKeysPerRequest,
         DistKeyValidityPeriod: entity.distKeyValidityPeriod,
-        DistCryptoSpec: common.DEFAULT_CIPHER + ':' + common.DEFAULT_MAC,
+        DistCryptoSpec: entity.distributionCryptoSpec.cipher + ':' + entity.distributionCryptoSpec.mac,
         Active: true,
         BackupToAuthIDs: entity.backupToAuthIds,
         BackupFromAuthID: -1

--- a/examples/configs/default.graph
+++ b/examples/configs/default.graph
@@ -71,6 +71,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
 			"credentialPrefix": "Net1.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -84,6 +92,14 @@
 			"maxSessionKeysPerRequest": 30,
 			"netName": "net1",
 			"credentialPrefix": "Net1.RcClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -97,6 +113,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
 			"credentialPrefix": "Net1.UdpClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -110,6 +134,14 @@
 			"maxSessionKeysPerRequest": 30,
 			"netName": "net1",
 			"credentialPrefix": "Net1.RcUdpClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -124,6 +156,14 @@
 			"diffieHellman": "secp384r1",
 			"netName": "net1",
 			"credentialPrefix": "Net1.SafetyCriticalClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -138,6 +178,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net1",
 			"credentialPrefix": "Net1.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				102
@@ -153,6 +201,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net1",
 			"credentialPrefix": "Net1.RcServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				102
@@ -168,6 +224,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net1",
 			"credentialPrefix": "Net1.UdpServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				102
@@ -184,6 +248,14 @@
 			"diffieHellman": "secp384r1",
 			"netName": "net1",
 			"credentialPrefix": "Net1.SafetyCriticalServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				102
@@ -199,6 +271,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net1",
 			"credentialPrefix": "Net1.RcUdpServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				102
@@ -214,6 +294,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
 			"credentialPrefix": "Net1.PtClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -229,6 +317,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net1",
 			"credentialPrefix": "Net1.PtServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				102
@@ -244,6 +340,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
 			"credentialPrefix": "Net1.PtPublisher",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -258,6 +362,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
 			"credentialPrefix": "Net1.PtSubscriber",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -271,6 +383,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net2",
 			"credentialPrefix": "Net2.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101
 			]
@@ -284,6 +404,14 @@
 			"maxSessionKeysPerRequest": 30,
 			"netName": "net2",
 			"credentialPrefix": "Net2.RcClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101
 			]
@@ -297,6 +425,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net2",
 			"credentialPrefix": "Net2.UdpClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101
 			]
@@ -310,6 +446,14 @@
 			"maxSessionKeysPerRequest": 30,
 			"netName": "net2",
 			"credentialPrefix": "Net2.RcUdpClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101
 			]
@@ -324,6 +468,14 @@
 			"diffieHellman": "secp384r1",
 			"netName": "net2",
 			"credentialPrefix": "Net2.SafetyCriticalClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101
 			]
@@ -338,6 +490,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net2",
 			"credentialPrefix": "Net2.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				101
@@ -353,6 +513,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net2",
 			"credentialPrefix": "Net2.RcServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				101
@@ -368,6 +536,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net2",
 			"credentialPrefix": "Net2.UdpServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				101
@@ -384,6 +560,14 @@
 			"diffieHellman": "secp384r1",
 			"netName": "net2",
 			"credentialPrefix": "Net2.SafetyCriticalServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				101
@@ -399,6 +583,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net2",
 			"credentialPrefix": "Net2.RcUdpServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				101
@@ -414,6 +606,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net2",
 			"credentialPrefix": "Net2.PtClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101
 			]
@@ -429,6 +629,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net2",
 			"credentialPrefix": "Net2.PtServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				101
@@ -444,6 +652,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net2",
 			"credentialPrefix": "Net2.PtPublisher",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101
 			]
@@ -458,6 +674,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net2",
 			"credentialPrefix": "Net2.PtSubscriber",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101
 			]

--- a/examples/configs/default_three_auths.graph
+++ b/examples/configs/default_three_auths.graph
@@ -105,6 +105,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
 			"credentialPrefix": "Net1.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -118,6 +126,14 @@
 			"maxSessionKeysPerRequest": 30,
 			"netName": "net1",
 			"credentialPrefix": "Net1.RcClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -131,6 +147,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
 			"credentialPrefix": "Net1.UdpClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -144,6 +168,14 @@
 			"maxSessionKeysPerRequest": 30,
 			"netName": "net1",
 			"credentialPrefix": "Net1.RcUdpClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -158,6 +190,14 @@
 			"diffieHellman": "secp384r1",
 			"netName": "net1",
 			"credentialPrefix": "Net1.SafetyCriticalClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -172,6 +212,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net1",
 			"credentialPrefix": "Net1.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				102
@@ -187,6 +235,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net1",
 			"credentialPrefix": "Net1.RcServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				102
@@ -202,6 +258,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net1",
 			"credentialPrefix": "Net1.UdpServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				102
@@ -218,6 +282,14 @@
 			"diffieHellman": "secp384r1",
 			"netName": "net1",
 			"credentialPrefix": "Net1.SafetyCriticalServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				102
@@ -233,6 +305,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net1",
 			"credentialPrefix": "Net1.RcUdpServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				102
@@ -248,6 +328,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
 			"credentialPrefix": "Net1.PtClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -263,6 +351,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net1",
 			"credentialPrefix": "Net1.PtServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				102
@@ -278,6 +374,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
 			"credentialPrefix": "Net1.PtPublisher",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -292,6 +396,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
 			"credentialPrefix": "Net1.PtSubscriber",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -305,6 +417,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net2",
 			"credentialPrefix": "Net2.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				103
 			]
@@ -318,6 +438,14 @@
 			"maxSessionKeysPerRequest": 30,
 			"netName": "net2",
 			"credentialPrefix": "Net2.RcClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				103
 			]
@@ -331,6 +459,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net2",
 			"credentialPrefix": "Net2.UdpClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				103
 			]
@@ -344,6 +480,14 @@
 			"maxSessionKeysPerRequest": 30,
 			"netName": "net2",
 			"credentialPrefix": "Net2.RcUdpClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				103
 			]
@@ -358,6 +502,14 @@
 			"diffieHellman": "secp384r1",
 			"netName": "net2",
 			"credentialPrefix": "Net2.SafetyCriticalClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				103
 			]
@@ -372,6 +524,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net2",
 			"credentialPrefix": "Net2.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				103
@@ -387,6 +547,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net2",
 			"credentialPrefix": "Net2.RcServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				103
@@ -402,6 +570,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net2",
 			"credentialPrefix": "Net2.UdpServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				103
@@ -418,6 +594,14 @@
 			"diffieHellman": "secp384r1",
 			"netName": "net2",
 			"credentialPrefix": "Net2.SafetyCriticalServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				103
@@ -433,6 +617,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net2",
 			"credentialPrefix": "Net2.RcUdpServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				103
@@ -448,6 +640,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net2",
 			"credentialPrefix": "Net2.PtClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				103
 			]
@@ -463,6 +663,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net2",
 			"credentialPrefix": "Net2.PtServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				103
@@ -478,6 +686,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net2",
 			"credentialPrefix": "Net2.PtPublisher",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				103
 			]
@@ -492,6 +708,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net2",
 			"credentialPrefix": "Net2.PtSubscriber",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				103
 			]
@@ -505,6 +729,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net3",
 			"credentialPrefix": "Net3.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101
 			]
@@ -518,6 +750,14 @@
 			"maxSessionKeysPerRequest": 30,
 			"netName": "net3",
 			"credentialPrefix": "Net3.RcClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101
 			]
@@ -531,6 +771,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net3",
 			"credentialPrefix": "Net3.UdpClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101
 			]
@@ -544,6 +792,14 @@
 			"maxSessionKeysPerRequest": 30,
 			"netName": "net3",
 			"credentialPrefix": "Net3.RcUdpClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101
 			]
@@ -558,6 +814,14 @@
 			"diffieHellman": "secp384r1",
 			"netName": "net3",
 			"credentialPrefix": "Net3.SafetyCriticalClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101
 			]
@@ -572,6 +836,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net3",
 			"credentialPrefix": "Net3.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				101
@@ -587,6 +859,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net3",
 			"credentialPrefix": "Net3.RcServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				101
@@ -602,6 +882,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net3",
 			"credentialPrefix": "Net3.UdpServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				101
@@ -618,6 +906,14 @@
 			"diffieHellman": "secp384r1",
 			"netName": "net3",
 			"credentialPrefix": "Net3.SafetyCriticalServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				101
@@ -633,6 +929,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net3",
 			"credentialPrefix": "Net3.RcUdpServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				101
@@ -648,6 +952,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net3",
 			"credentialPrefix": "Net3.PtClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101
 			]
@@ -663,6 +975,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net3",
 			"credentialPrefix": "Net3.PtServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				101
@@ -678,6 +998,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net3",
 			"credentialPrefix": "Net3.PtPublisher",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101
 			]
@@ -692,6 +1020,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net3",
 			"credentialPrefix": "Net3.PtSubscriber",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101
 			]

--- a/examples/configs/default_three_auths_backup_to_all.graph
+++ b/examples/configs/default_three_auths_backup_to_all.graph
@@ -105,6 +105,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
 			"credentialPrefix": "Net1.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102,
 				103
@@ -119,6 +127,14 @@
 			"maxSessionKeysPerRequest": 30,
 			"netName": "net1",
 			"credentialPrefix": "Net1.RcClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102,
 				103
@@ -132,7 +148,23 @@
 			"distKeyValidityPeriod": "1*hour",
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
-			"credentialPrefix": "Net1.UdpClient",
+			"credentialPre
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},fix": "Net1.UdpClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102,
 				103
@@ -147,6 +179,14 @@
 			"maxSessionKeysPerRequest": 30,
 			"netName": "net1",
 			"credentialPrefix": "Net1.RcUdpClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102,
 				103
@@ -162,6 +202,14 @@
 			"diffieHellman": "secp384r1",
 			"netName": "net1",
 			"credentialPrefix": "Net1.SafetyCriticalClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102,
 				103
@@ -177,6 +225,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net1",
 			"credentialPrefix": "Net1.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				102,
@@ -193,6 +249,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net1",
 			"credentialPrefix": "Net1.RcServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				102,
@@ -209,6 +273,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net1",
 			"credentialPrefix": "Net1.UdpServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				102,
@@ -226,6 +298,14 @@
 			"diffieHellman": "secp384r1",
 			"netName": "net1",
 			"credentialPrefix": "Net1.SafetyCriticalServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				102,
@@ -242,6 +322,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net1",
 			"credentialPrefix": "Net1.RcUdpServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				102,
@@ -258,6 +346,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
 			"credentialPrefix": "Net1.PtClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102,
 				103
@@ -274,6 +370,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net1",
 			"credentialPrefix": "Net1.PtServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				102,
@@ -290,6 +394,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
 			"credentialPrefix": "Net1.PtPublisher",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102,
 				103
@@ -305,6 +417,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
 			"credentialPrefix": "Net1.PtSubscriber",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102,
 				103
@@ -319,6 +439,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net2",
 			"credentialPrefix": "Net2.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				103,
 				101
@@ -333,6 +461,14 @@
 			"maxSessionKeysPerRequest": 30,
 			"netName": "net2",
 			"credentialPrefix": "Net2.RcClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				103,
 				101
@@ -347,6 +483,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net2",
 			"credentialPrefix": "Net2.UdpClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				103,
 				101
@@ -361,6 +505,14 @@
 			"maxSessionKeysPerRequest": 30,
 			"netName": "net2",
 			"credentialPrefix": "Net2.RcUdpClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				103,
 				101
@@ -376,6 +528,14 @@
 			"diffieHellman": "secp384r1",
 			"netName": "net2",
 			"credentialPrefix": "Net2.SafetyCriticalClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				103,
 				101
@@ -391,6 +551,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net2",
 			"credentialPrefix": "Net2.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				103,
@@ -407,6 +575,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net2",
 			"credentialPrefix": "Net2.RcServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				103,
@@ -423,6 +599,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net2",
 			"credentialPrefix": "Net2.UdpServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				103,
@@ -440,6 +624,14 @@
 			"diffieHellman": "secp384r1",
 			"netName": "net2",
 			"credentialPrefix": "Net2.SafetyCriticalServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				103,
@@ -456,6 +648,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net2",
 			"credentialPrefix": "Net2.RcUdpServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				103,
@@ -472,6 +672,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net2",
 			"credentialPrefix": "Net2.PtClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				103,
 				101
@@ -488,6 +696,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net2",
 			"credentialPrefix": "Net2.PtServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				103,
@@ -504,6 +720,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net2",
 			"credentialPrefix": "Net2.PtPublisher",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				103,
 				101
@@ -519,6 +743,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net2",
 			"credentialPrefix": "Net2.PtSubscriber",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				103,
 				101
@@ -533,6 +765,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net3",
 			"credentialPrefix": "Net3.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101,
 				102
@@ -547,6 +787,14 @@
 			"maxSessionKeysPerRequest": 30,
 			"netName": "net3",
 			"credentialPrefix": "Net3.RcClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101,
 				102
@@ -561,6 +809,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net3",
 			"credentialPrefix": "Net3.UdpClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101,
 				102
@@ -575,6 +831,14 @@
 			"maxSessionKeysPerRequest": 30,
 			"netName": "net3",
 			"credentialPrefix": "Net3.RcUdpClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101,
 				102
@@ -590,6 +854,14 @@
 			"diffieHellman": "secp384r1",
 			"netName": "net3",
 			"credentialPrefix": "Net3.SafetyCriticalClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101,
 				102
@@ -605,6 +877,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net3",
 			"credentialPrefix": "Net3.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				101,
@@ -621,6 +901,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net3",
 			"credentialPrefix": "Net3.RcServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				101,
@@ -637,6 +925,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net3",
 			"credentialPrefix": "Net3.UdpServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				101,
@@ -654,6 +950,14 @@
 			"diffieHellman": "secp384r1",
 			"netName": "net3",
 			"credentialPrefix": "Net3.SafetyCriticalServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				101,
@@ -670,6 +974,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net3",
 			"credentialPrefix": "Net3.RcUdpServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				101,
@@ -686,6 +998,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net3",
 			"credentialPrefix": "Net3.PtClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101,
 				102
@@ -702,6 +1022,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net3",
 			"credentialPrefix": "Net3.PtServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				101,
@@ -718,6 +1046,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net3",
 			"credentialPrefix": "Net3.PtPublisher",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101,
 				102
@@ -733,6 +1069,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net3",
 			"credentialPrefix": "Net3.PtSubscriber",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101,
 				102

--- a/examples/configs/file_sharing.graph
+++ b/examples/configs/file_sharing.graph
@@ -55,6 +55,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
 			"credentialPrefix": "Net1.Uploader",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -70,6 +78,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
 			"credentialPrefix": "Net1.Downloader",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -85,6 +101,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
 			"credentialPrefix": "Net1.Alice",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -100,6 +124,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
 			"credentialPrefix": "Net1.Bob",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -113,6 +145,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
 			"credentialPrefix": "Net1.FileSystemManager",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -126,6 +166,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net2",
 			"credentialPrefix": "Net2.Uploader",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101
 			]
@@ -141,6 +189,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net2",
 			"credentialPrefix": "Net2.Downloader",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101
 			]
@@ -156,6 +212,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net2",
 			"credentialPrefix": "Net2.Alice",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101
 			]
@@ -171,6 +235,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net2",
 			"credentialPrefix": "Net2.Bob",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101
 			]
@@ -184,6 +256,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net2",
 			"credentialPrefix": "Net2.FileSystemManager",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				101
 			]

--- a/examples/configs/lf_sst.graph
+++ b/examples/configs/lf_sst.graph
@@ -49,6 +49,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net1",
 			"credentialPrefix": "Net1.rti",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"host": "localhost",
 			"backupToAuthIds": [
 				102
@@ -63,6 +71,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
 			"credentialPrefix": "Net1.federate__fed1",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -76,6 +92,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
 			"credentialPrefix": "Net1.federate__fed2",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -89,6 +113,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
 			"credentialPrefix": "Net1.Fed_2",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]
@@ -102,6 +134,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
 			"credentialPrefix": "Net1.Fed_3",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				102
 			]

--- a/examples/configs/rocksdb.graph
+++ b/examples/configs/rocksdb.graph
@@ -33,7 +33,7 @@
 	],
 	"assignments": {
 		"net1.compute_node": 101,
-		"net1.compaction_node": 101,
+		"net1.compaction_node_CTR": 101,
 		"net1.compute_node_GCM": 101,
 		"net1.compaction_node_GCM": 101,
 		"net1.compute_node_CBC": 101,
@@ -41,7 +41,7 @@
 	},
 	"entityList": [
 		{
-			"group": "ComputeNodes",
+			"group": "ComputeNodesCTR",
 			"name": "net1.compute_node",
 			"distProtocol": "TCP",
 			"usePermanentDistKey": false,
@@ -62,15 +62,15 @@
 			]
 		},
 		{
-			"group": "CompactionNodes",
-			"name": "net1.compaction_node",
+			"group": "CompactionNodesCTR",
+			"name": "net1.compaction_node_CTR",
 			"port": 21100,
 			"distProtocol": "TCP",
 			"usePermanentDistKey": false,
 			"distKeyValidityPeriod": "1*hour",
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net1",
-			"credentialPrefix": "Net1.compaction_node",
+			"credentialPrefix": "Net1.compaction_node_CTR",
 			"distributionCryptoSpec": {
 				"cipher": "AES-128-CTR",
 				"mac": "SHA256"

--- a/examples/configs/rocksdb.graph
+++ b/examples/configs/rocksdb.graph
@@ -33,7 +33,11 @@
 	],
 	"assignments": {
 		"net1.compute_node": 101,
-		"net1.compaction_node": 101
+		"net1.compaction_node": 101,
+		"net1.compute_node_GCM": 101,
+		"net1.compaction_node_GCM": 101,
+		"net1.compute_node_CBC": 101,
+		"net1.compaction_node_CBC": 101
 	},
 	"entityList": [
 		{
@@ -73,6 +77,94 @@
 			},
 			"sessionCryptoSpec": {
 				"cipher": "AES-128-CTR",
+				"mac": "SHA256"
+			},
+			"host": "localhost",
+			"backupToAuthIds": [
+				102
+			]
+		},
+		{
+			"group": "ComputeNodesGCM",
+			"name": "net1.compute_node_GCM",
+			"distProtocol": "TCP",
+			"usePermanentDistKey": false,
+			"distKeyValidityPeriod": "1*hour",
+			"maxSessionKeysPerRequest": 5,
+			"netName": "net1",
+			"credentialPrefix": "Net1.compute_node_GCM",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-GCM",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-GCM",
+				"mac": "SHA256"
+			},
+			"backupToAuthIds": [
+				102
+			]
+		},
+		{
+			"group": "CompactionNodesGCM",
+			"name": "net1.compaction_node_GCM",
+			"port": 21100,
+			"distProtocol": "TCP",
+			"usePermanentDistKey": false,
+			"distKeyValidityPeriod": "1*hour",
+			"maxSessionKeysPerRequest": 1,
+			"netName": "net1",
+			"credentialPrefix": "Net1.compaction_node_GCM",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-GCM",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-GCM",
+				"mac": "SHA256"
+			},
+			"host": "localhost",
+			"backupToAuthIds": [
+				102
+			]
+		},
+		{
+			"group": "ComputeNodesCBC",
+			"name": "net1.compute_node_CBC",
+			"distProtocol": "TCP",
+			"usePermanentDistKey": false,
+			"distKeyValidityPeriod": "1*hour",
+			"maxSessionKeysPerRequest": 5,
+			"netName": "net1",
+			"credentialPrefix": "Net1.compute_node_CBC",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"backupToAuthIds": [
+				102
+			]
+		},
+		{
+			"group": "CompactionNodesCBC",
+			"name": "net1.compaction_node_CBC",
+			"port": 21100,
+			"distProtocol": "TCP",
+			"usePermanentDistKey": false,
+			"distKeyValidityPeriod": "1*hour",
+			"maxSessionKeysPerRequest": 1,
+			"netName": "net1",
+			"credentialPrefix": "Net1.compaction_node_CBC",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
 				"mac": "SHA256"
 			},
 			"host": "localhost",

--- a/examples/configs/rocksdb.graph
+++ b/examples/configs/rocksdb.graph
@@ -1,0 +1,85 @@
+{
+	"authList": [
+		{
+			"id": 101,
+			"entityHost": "localhost",
+			"authHost": "localhost",
+			"tcpPort": 21900,
+			"udpPort": 21902,
+			"authPort": 21901,
+			"callbackPort": 21903,
+			"dbProtectionMethod": 1,
+			"backupEnabled": false,
+			"contextualCallbackEnabled": true
+		},
+		{
+			"id": 102,
+			"entityHost": "localhost",
+			"authHost": "localhost",
+			"tcpPort": 22900,
+			"udpPort": 22902,
+			"authPort": 22901,
+			"callbackPort": 22903,
+			"dbProtectionMethod": 1,
+			"backupEnabled": false,
+			"contextualCallbackEnabled": true
+		}
+	],
+	"authTrusts": [
+		{
+			"id1": 101,
+			"id2": 102
+		}
+	],
+	"assignments": {
+		"net1.compute_server": 101,
+		"net1.compaction_server": 101
+	},
+	"entityList": [
+		{
+			"group": "Clients",
+			"name": "net1.compute_server",
+			"distProtocol": "TCP",
+			"usePermanentDistKey": false,
+			"distKeyValidityPeriod": "1*hour",
+			"maxSessionKeysPerRequest": 5,
+			"netName": "net1",
+			"credentialPrefix": "Net1.compute_server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CTR",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CTR",
+				"mac": "SHA256"
+			},
+			"backupToAuthIds": [
+				102
+			]
+		},
+		{
+			"group": "Servers",
+			"name": "net1.compaction_server",
+			"port": 21100,
+			"distProtocol": "TCP",
+			"usePermanentDistKey": false,
+			"distKeyValidityPeriod": "1*hour",
+			"maxSessionKeysPerRequest": 1,
+			"netName": "net1",
+			"credentialPrefix": "Net1.compaction_server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CTR",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CTR",
+				"mac": "SHA256"
+			},
+			"host": "localhost",
+			"backupToAuthIds": [
+				102
+			]
+		}
+	],
+	"filesharingLists": []
+}

--- a/examples/configs/rocksdb.graph
+++ b/examples/configs/rocksdb.graph
@@ -32,19 +32,19 @@
 		}
 	],
 	"assignments": {
-		"net1.compute_server": 101,
-		"net1.compaction_server": 101
+		"net1.compute_node": 101,
+		"net1.compaction_node": 101
 	},
 	"entityList": [
 		{
-			"group": "Clients",
-			"name": "net1.compute_server",
+			"group": "ComputeNodes",
+			"name": "net1.compute_node",
 			"distProtocol": "TCP",
 			"usePermanentDistKey": false,
 			"distKeyValidityPeriod": "1*hour",
 			"maxSessionKeysPerRequest": 5,
 			"netName": "net1",
-			"credentialPrefix": "Net1.compute_server",
+			"credentialPrefix": "Net1.compute_node",
 			"distributionCryptoSpec": {
 				"cipher": "AES-128-CTR",
 				"mac": "SHA256"
@@ -58,15 +58,15 @@
 			]
 		},
 		{
-			"group": "Servers",
-			"name": "net1.compaction_server",
+			"group": "CompactionNodes",
+			"name": "net1.compaction_node",
 			"port": 21100,
 			"distProtocol": "TCP",
 			"usePermanentDistKey": false,
 			"distKeyValidityPeriod": "1*hour",
 			"maxSessionKeysPerRequest": 1,
 			"netName": "net1",
-			"credentialPrefix": "Net1.compaction_server",
+			"credentialPrefix": "Net1.compaction_node",
 			"distributionCryptoSpec": {
 				"cipher": "AES-128-CTR",
 				"mac": "SHA256"

--- a/examples/entityConfigGenerator.js
+++ b/examples/entityConfigGenerator.js
@@ -131,24 +131,14 @@ function getCryptoInfo(entity) {
             cryptoInfo.publicKeyCryptoSpec.diffieHellman = entity.diffieHellman;
         }
     }
-    if (entity.distributionCryptoSpec != null) {
-    } else {
-		entity.distributionCryptoSpec.cipher = common.DEFAULT_CIPHER;
-		entity.distributionCryptoSpec.mac = common.DEFAULT_MAC;
-    }
-	cryptoInfo.distributionCryptoSpec = {
-		'cipher': entity.distributionCryptoSpec.cipher,
-		'mac': entity.distributionCryptoSpec.mac,
-	};
-    if (entity.sessionCryptoSpec != null) {
-    } else {
-		entity.sessionCryptoSpec.cipher = common.DEFAULT_CIPHER;
-		entity.sessionCryptoSpec.mac = common.DEFAULT_MAC;
-    }
-	cryptoInfo.sessionCryptoSpec = {
-		'cipher': entity.sessionCryptoSpec.cipher,
-		'mac': entity.sessionCryptoSpec.mac,
-	};
+    cryptoInfo.distributionCryptoSpec = {
+        'cipher': entity.distributionCryptoSpec.cipher,
+        'mac': entity.distributionCryptoSpec.mac,
+    };
+    cryptoInfo.sessionCryptoSpec = {
+        'cipher': entity.sessionCryptoSpec.cipher,
+        'mac': entity.sessionCryptoSpec.mac,
+    };
     if (entity.diffieHellman != null) {
         cryptoInfo.sessionCryptoSpec.diffieHellman = entity.diffieHellman;
     }

--- a/examples/entityConfigGenerator.js
+++ b/examples/entityConfigGenerator.js
@@ -131,14 +131,24 @@ function getCryptoInfo(entity) {
             cryptoInfo.publicKeyCryptoSpec.diffieHellman = entity.diffieHellman;
         }
     }
-    cryptoInfo.distributionCryptoSpec = {
-        'cipher': common.DEFAULT_CIPHER,
-        'mac': common.DEFAULT_MAC
-    };
-    cryptoInfo.sessionCryptoSpec = {
-        'cipher': common.DEFAULT_CIPHER,
-        'mac': common.DEFAULT_MAC
-    };
+    if (entity.distributionCryptoSpec != null) {
+    } else {
+		entity.distributionCryptoSpec.cipher = common.DEFAULT_CIPHER;
+		entity.distributionCryptoSpec.mac = common.DEFAULT_MAC;
+    }
+	cryptoInfo.distributionCryptoSpec = {
+		'cipher': entity.distributionCryptoSpec.cipher,
+		'mac': entity.distributionCryptoSpec.mac,
+	};
+    if (entity.sessionCryptoSpec != null) {
+    } else {
+		entity.sessionCryptoSpec.cipher = common.DEFAULT_CIPHER;
+		entity.sessionCryptoSpec.mac = common.DEFAULT_MAC;
+    }
+	cryptoInfo.sessionCryptoSpec = {
+		'cipher': entity.sessionCryptoSpec.cipher,
+		'mac': entity.sessionCryptoSpec.mac,
+	};
     if (entity.diffieHellman != null) {
         cryptoInfo.sessionCryptoSpec.diffieHellman = entity.diffieHellman;
     }


### PR DESCRIPTION
Please merge with iotauth/sst-c-api#7.

1. This enables different CryptoSpecs for distribution keys and session keys.

The existing code only enables AES-128-CTR mode, hard-coded. This code makes the user to specify the cipher and mac type, by the following format, in the `graph` file.

```
			"distributionCryptoSpec": {
				"cipher": "AES-128-CTR",
				"mac": "SHA256"
			},
			"sessionCryptoSpec": {
				"cipher": "AES-128-CTR",
				"mac": "SHA256"
			}
```

So, all default changes now have a CryptoSpec for distribution and session keys.

2. Rocksdb graphs and communication policies are added.
Test is available generating commands with the Rocksdb graphs.
```
./generateAll.sh -g configs/rocksdb.graph
```
3. Debugging environments of the Auth at VSCode were also added in the [README.md](https://github.com/iotauth/iotauth/blob/aes-ctr-support/auth/README.md)