### PR TITLE
Fix 'file_system_manager''s config to load the authID. & Fix invisible Unicode char in node example. & Fix node logic to check AuthID.

### DIFF
--- a/entity/node/accessors/node_modules/iotAuth.js
+++ b/entity/node/accessors/node_modules/iotAuth.js
@@ -98,6 +98,7 @@ exports.getSessionKeyReqOptions = function(entityConfig, distributionKey, purpos
     return {
         authHost: entityConfig.authInfo.host,
         authPort: entityConfig.authInfo.port,
+        authId:entityConfig.authInfo.id,
         entityName: entityConfig.entityInfo.name,
         numKeysPerRequest: numKeys,
         purpose: purpose,

--- a/entity/node/accessors/node_modules/iotAuthService.js
+++ b/entity/node/accessors/node_modules/iotAuthService.js
@@ -325,6 +325,13 @@ function sendSessionKeyReqHelper(helperOptions, helperEventHandlers, options, se
         console.log('received auth hello!');
         var obj = parseAuthHello(helperOptions.payload);
         console.log(obj);
+        console.log(obj.authId);
+        console.log(options);
+        if (obj.authId === options.authId) {
+            console.log('auth id matches');
+        } else {
+            throw 'auth id mismatch';
+        }
         helperOptions.myNonce = generateAuthNonce();
 
         var sessionKeyReq = {
@@ -458,6 +465,8 @@ eventHandlers = {
 }
 */
 exports.sendSessionKeyReqViaTCP = function(options, sessionKeyRespHandler, eventHandlers, callbackParams) {
+    console.log("sendSessionKeyReqViaTCP was called");
+    console.log(options);
     var myNonce;
     var myECDH;
     var expectingMoreData = false;

--- a/entity/node/accessors/node_modules/iotAuthService.js
+++ b/entity/node/accessors/node_modules/iotAuthService.js
@@ -325,8 +325,6 @@ function sendSessionKeyReqHelper(helperOptions, helperEventHandlers, options, se
         console.log('received auth hello!');
         var obj = parseAuthHello(helperOptions.payload);
         console.log(obj);
-        console.log(obj.authId);
-        console.log(options);
         if (obj.authId === options.authId) {
             console.log('auth id matches');
         } else {
@@ -465,7 +463,6 @@ eventHandlers = {
 }
 */
 exports.sendSessionKeyReqViaTCP = function(options, sessionKeyRespHandler, eventHandlers, callbackParams) {
-    console.log(options);
     var myNonce;
     var myECDH;
     var expectingMoreData = false;

--- a/entity/node/accessors/node_modules/iotAuthService.js
+++ b/entity/node/accessors/node_modules/iotAuthService.js
@@ -751,7 +751,7 @@ function sendMigrationReqHelper(helperOptions, helperEventHandlers, options, mig
             }
             console.log('Certificate of new Auth is verified!');
             var authCertSubject = x509.subject;
-	    var ouMatchResult = authCertSubject.match(/^OU=(.+)$/m);
+	    var ouMatchResult = authCertSubject.match(/^OU=(.+)$/m);
 	    if (ouMatchResult.length < 2){
 		helperEventHandlers.onError('Organizational Unit not found in certificate subject!' + authCertSubject);
 		return;

--- a/entity/node/accessors/node_modules/iotAuthService.js
+++ b/entity/node/accessors/node_modules/iotAuthService.js
@@ -330,7 +330,7 @@ function sendSessionKeyReqHelper(helperOptions, helperEventHandlers, options, se
         if (obj.authId === options.authId) {
             console.log('auth id matches');
         } else {
-            throw 'auth id mismatch';
+            return {success: false, error: 'auth id mismatch' }
         }
         helperOptions.myNonce = generateAuthNonce();
 
@@ -465,7 +465,6 @@ eventHandlers = {
 }
 */
 exports.sendSessionKeyReqViaTCP = function(options, sessionKeyRespHandler, eventHandlers, callbackParams) {
-    console.log("sendSessionKeyReqViaTCP was called");
     console.log(options);
     var myNonce;
     var myECDH;

--- a/examples/file_sharing/file_system_manager.config
+++ b/examples/file_sharing/file_system_manager.config
@@ -1,6 +1,7 @@
 name=net1.FileSystemManager
 purpose={"keyId":00000000}
 number_key=1
+authInfo.id=101
 auth_pubkey_path=../../entity/auth_certs/Auth101EntityCert.pem
 privkey_path=../../entity/credentials/keys/net1/Net1.FileSystemManagerKey.pem
 auth_ip_address=127.0.0.1


### PR DESCRIPTION
1. Additional fix on config for `file_system_manager` iotauth/sst-c-api#37


2. Remove the invisible Unicode character at the end of the line, making the code not work. This was from #49.
Attached image below with logs.
![image](https://github.com/user-attachments/assets/c0e77379-3ec8-42f0-9615-8484a64ca104)

```
/Users/dkim314/project/sst-test/entity/node/accessors/node_modules/iotAuthService.js:754
            var ouMatchResult = authCertSubject.match(/^OU=(.+)$/m);
                                                                    ^

SyntaxError: Invalid or unexpected token
    at wrapSafe (node:internal/modules/cjs/loader:1666:18)
    at Module._compile (node:internal/modules/cjs/loader:1708:20)
    at Object..js (node:internal/modules/cjs/loader:1899:10)
    at Module.load (node:internal/modules/cjs/loader:1469:32)
    at Function._load (node:internal/modules/cjs/loader:1286:12)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
    at Module.require (node:internal/modules/cjs/loader:1491:12)
    at require (node:internal/modules/helpers:135:16)
    at Object.<anonymous> (/Users/dkim314/project/sst-test/entity/node/accessors/node_modules/iotAuth.js:35:22)

Node.js v23.11.0
```

3. Add checking authId as issue in iotauth/sst-c-api#28

