### PR TITLE
Python API fix for 'auth_id' handling. & Fix README.md to match the updated path.

### DIFF
--- a/entity/python/entity_server.py
+++ b/entity/python/entity_server.py
@@ -27,7 +27,7 @@ NONCE_SIZE = 8
 ABS_VALIDITY_SIZE = 6
 REL_VALIDITY_SIZE = 6
 IV_SIZE = 16
-AUTH_ID = 4
+AUTH_ID_LEN = 4
 KEY_NUM_BUF = 4
 SEQ_NUM_SIZE = 8
 AUTH_HELLO = 0
@@ -416,8 +416,14 @@ def get_session_key(buffer: bytearray, config_dict: dict, sock: socket.socket, d
     length, length_buf = var_length_int_to_num(buffer[1:])
 
     if msg_type == AUTH_HELLO:
+        # Extract and validate auth_id (big-endian)
+        received_auth_id = read_unsigned_int_BE(buffer[1+length_buf:], AUTH_ID_LEN)
+        expected_auth_id = int(config_dict['authid'])
+        if received_auth_id != expected_auth_id:
+            print("Auth ID NOT matched.")
+            return 
         # Handle AUTH_HELLO message
-        nonce_auth = buffer[AUTH_ID+1+length_buf:]
+        nonce_auth = buffer[AUTH_ID_LEN+1+length_buf:]
         serialize_message = serialize_message_for_auth(config_dict, nonce_auth, nonce_entity)
         ciphertext = asymmetric_encrypt(serialize_message, config_dict['pubkey'])
         signature = sha256_sign(ciphertext, config_dict['privkey'])

--- a/entity/python/entity_server.py
+++ b/entity/python/entity_server.py
@@ -66,6 +66,8 @@ def load_config(path: str, config_dict: dict) -> None:
             config_dict["purpose"] = content
         elif index == "number_key":
             config_dict["number_key"] = content
+        elif index == "authid":
+            config_dict["authid"] = content
         elif index == "auth_pubkey_path":
             config_dict["auth_pubkey_path"] = content
         elif index == "privkey_path":

--- a/examples/file_sharing/README.md
+++ b/examples/file_sharing/README.md
@@ -57,7 +57,7 @@ See README.md under *examples/* for details.
 
 1. Run `git submodule update --remote` to update the `sst-c-api` submodule.
 
-2. Change directories to `$ROOT/entity/c/examples/ipfs_examples/` (Move the file for experiment in this directory and change the file name to "plain_text")
+2. Change directories to `$ROOT/entity/c/examples/ipfs_examples/c` (Move the file for experiment in this directory and change the file name to "plain_text")
 
 3. Run `mkdir build && cd build`
 
@@ -65,9 +65,9 @@ See README.md under *examples/* for details.
 
 5. Run `make` 
 
-6. Run `./entity_uploader ../uploader.config ../plain_text ../addReader.txt` in a separate terminal, to execute net1.uploader.
+6. Run `./entity_uploader ../../uploader.config ../../plain_text ../../addReader.txt` in a separate terminal, to execute net1.uploader.
 
-7. Run `./entity_downloader ../downloader.config`, to execute net1.downloader.
+7. Run `./entity_downloader ../../downloader.config`, to execute net1.downloader.
 
 # Security for File System Manager
 ---
@@ -115,9 +115,9 @@ The process is the same as the above example.
 
 5. Run `make` 
 
-6. [*Optional*] To create a plain text file to be encrypted, run `head -c 1024 < /dev/urandom > plain_text`, for example, to create a random binary file of size of 1024 bytes.
+6. [*Optional*] To create a plain text file to be encrypted, run `head -c 1024 < /dev/urandom > ../../plain_text`, for example, to create a random binary file of size of 1024 bytes.
 
-7. Run `./secure_entity_uploader ../../secure_uploader.config plain_text ../../addReader.txt` in a separate terminal, to execute `net1.uploader`. NOTE: `plain_text` is a file to be encrypted and uploaded (can be any file), and `addReader.txt` is a file including a list of readers to be added dynamically. Below is an example `addReader.txt` file.
+7. Run `./secure_entity_uploader ../../secure_uploader.config ../../plain_text ../../addReader.txt` in a separate terminal, to execute `net1.uploader`. NOTE: `plain_text` is a file to be encrypted and uploaded (can be any file), and `addReader.txt` is a file including a list of readers to be added dynamically. Below is an example `addReader.txt` file.
    ```
    {"AddReader":"net1.Bob"}
    {"AddReader":"net1.Alice"}

--- a/examples/file_sharing/file_system_manager.config
+++ b/examples/file_sharing/file_system_manager.config
@@ -1,7 +1,7 @@
 name=net1.FileSystemManager
 purpose={"keyId":00000000}
 number_key=1
-authInfo.id=101
+authid=101
 auth_pubkey_path=../../entity/auth_certs/Auth101EntityCert.pem
 privkey_path=../../entity/credentials/keys/net1/Net1.FileSystemManagerKey.pem
 auth_ip_address=127.0.0.1


### PR DESCRIPTION
1. Fix the Python API to,
 - Load the authID from the config, 
 - and then compare with the received authID.
This was introduced in iotauth/sst-c-api#28

2. Fix the wrong command paths on the README.md for file_sharing, which was changed on iotauth/sst-c-api#31.

I will request review after #50 is merged due to branching from that branch.