### PR TITLE
Add password option for secure file system manager.

### DIFF
--- a/entity/python/entity_server.py
+++ b/entity/python/entity_server.py
@@ -834,3 +834,4 @@ def check_database(password, file_name: str, file_metadata_table: dict, record_h
         else :
             number = input("Generate the password for the database: ")
         return file_metadata_table, record_history_table, number
+    

--- a/entity/python/entity_server.py
+++ b/entity/python/entity_server.py
@@ -783,5 +783,9 @@ def check_database(password, file_name: str, file_metadata_table: dict, record_h
                 
     else:
         print("Database does not exist.")
-        number = input("Generate the password for the database: ")
+        if (password):
+            number = password
+            print("New database generated using password.")
+        else :
+            number = input("Generate the password for the database: ")
         return file_metadata_table, record_history_table, number

--- a/entity/python/entity_server.py
+++ b/entity/python/entity_server.py
@@ -746,7 +746,7 @@ def database_to_dict(data: str, dict: dict) -> dict:
     dict['hash_value'].append(data[2])
     return dict
 
-def check_database(file_name: str, file_metadata_table: dict, record_history_table: dict) -> tuple:
+def check_database(password, file_name: str, file_metadata_table: dict, record_history_table: dict) -> tuple:
     """
     Checks the existence of a database and retrieves its content.
 
@@ -760,7 +760,10 @@ def check_database(file_name: str, file_metadata_table: dict, record_history_tab
     """
     if os.path.isfile(file_name):
         print("Database already exists.")
-        number = input("Press the password for the database: ")
+        if (password):
+            number = password
+        else :
+            number = input("Press the password for the database: ")
         decrypted_data = decrypt_with_password(file_name, number)
         if decrypted_data == None:
             print("decryption was not applied!!")

--- a/examples/file_sharing/README.md
+++ b/examples/file_sharing/README.md
@@ -51,7 +51,9 @@ See README.md under *examples/* for details.
 
 1. Change directories to `$ROOT/examples/file_sharing/`.
 
-2. Run `python3 file_system_manager.py` to execute the file system manager.
+2. Install crypto library. `pip install pycryptodome`.
+
+3. Run `python3 file_system_manager.py` to execute the file system manager.
 
 ### To run example entities written in C language
 
@@ -99,9 +101,11 @@ The process is the same as the above example.
 
 1. Change directories to `$ROOT/examples/file_sharing/`.
 
-2. Run `python3 secure_file_system_manager.py file_system_manager.config` to execute the file system manager.
+2. Install crypto functions. `pip install pycryptodome`.
 
-3. Press the password for the database to get previous information.
+3. Run `python3 secure_file_system_manager.py file_system_manager.config` to execute the file system manager.
+
+4. Press the password for the database to get previous information (also `-p` or `--password` option works when executing).
 
 ### To run example entities written in C language
 

--- a/examples/file_sharing/README.md
+++ b/examples/file_sharing/README.md
@@ -105,7 +105,7 @@ The process is the same as the above example.
 
 3. Run `python3 secure_file_system_manager.py file_system_manager.config` to execute the file system manager.
 
-4. Press the password for the database to get previous information (also `-p` or `--password` option works when executing).
+4. The program will ask a password to type in for the database, or you can pass it as the executable input, using the `-p` or `--password` option (e.g., `python3 secure_file_system_manager.py file_system_manager.config -p asdf`).
 
 ### To run example entities written in C language
 

--- a/examples/file_sharing/README.md
+++ b/examples/file_sharing/README.md
@@ -35,7 +35,7 @@ Change the directory to `$ROOT/examples`.
 4. If there is any error or you want to start with a clean copy, you can delete all generated credentials and Auth databases by running the script *cleanAll.sh*, with the command `./cleanAll.sh`.
 
 ### To run IPFS (in command line)
-1. Run `ipfs daemon` to activate an IPFS environment. (IPFS command line tools should be installed a priori. If it is not installed, then you can install it easily by reading [IPFS install](https://docs.ipfs.tech/install/command-line/#install-official-binary-distributions)).
+1. Run `ipfs daemon` to activate an IPFS environment. (IPFS command line tools should be installed a priori. If it is not installed, then you can install it easily by reading [IPFS install](https://docs.ipfs.tech/install/command-line/#install-official-binary-distributions). Also run `ipfs init` if it's the initial execution of IPFS.)
 
 ### To run example Auths (in command line)
 See README.md under *examples/* for details.

--- a/examples/file_sharing/file_system_manager.config
+++ b/examples/file_sharing/file_system_manager.config
@@ -6,6 +6,6 @@ auth_pubkey_path=../../entity/auth_certs/Auth101EntityCert.pem
 privkey_path=../../entity/credentials/keys/net1/Net1.FileSystemManagerKey.pem
 auth_ip_address=127.0.0.1
 auth_port_number=21900
-port_number=21100
+port_number=22100
 ip_address=127.0.0.1
 network_protocol=TCP

--- a/examples/file_sharing/secure_file_system_manager.py
+++ b/examples/file_sharing/secure_file_system_manager.py
@@ -172,3 +172,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+    

--- a/examples/file_sharing/secure_file_system_manager.py
+++ b/examples/file_sharing/secure_file_system_manager.py
@@ -141,6 +141,10 @@ def main():
     node_selector = selectors.DefaultSelector()
 
     host, port = file_manager_dict["ip_address"], int(file_manager_dict["port_number"])
+    # Prevent binding to all interfaces for security
+    if host in ("", "0.0.0.0"):
+        print("Error: Refusing to bind to all interfaces (empty string or 0.0.0.0). Please specify a dedicated interface IP address in the config file.")
+        sys.exit(1)
 
     manager_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     manager_socket.bind((host, port))

--- a/examples/file_sharing/secure_file_system_manager.py
+++ b/examples/file_sharing/secure_file_system_manager.py
@@ -117,20 +117,9 @@ def service_connection(key, mask):
 
 def main():
     parser = argparse.ArgumentParser(description="Process config and optional password.")
-
-    # Positional argument: config path
     parser.add_argument("config", help="Path to config file")
-
-    # Optional: -p or --password
     parser.add_argument("-p", "--password", help="Password for authentication (optional)")
-
     args = parser.parse_args()
-
-    print(f"Config file: {args.config}")
-    if args.password:
-        print(f"Password: {args.password}")
-    else:
-        print("No password provided.")
 
     # Setting directories for config, distribution key, and session key
     file_manager_dict = {"name" : "", "purpose" : '', "number_key":"", "auth_pubkey_path":"", "privkey_path":"", "auth_ip_address":"", "auth_port_number":"", "port_number":"", "ip_address":"", "network_protocol":"", "pubkey": "", "privkey": ""}

--- a/examples/file_sharing/secure_file_system_manager.py
+++ b/examples/file_sharing/secure_file_system_manager.py
@@ -6,9 +6,14 @@ import os
 import types
 import argparse
 import secrets
-print(os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(__file__)))) +"/entity/python")
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(__file__)))) +"/entity/python")
+import selectors
+
+# Compute absolute path to /entity/python relative to this file
+base_dir = os.path.abspath(os.path.join(__file__, "..", "..", "..", "entity", "python"))
+sys.path.append(base_dir)
 import entity_server
+
+node_selector = selectors.DefaultSelector()
 
 def accept_wrapper(sock):
     """Accepts a connection and performs necessary setup.
@@ -172,4 +177,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-    


### PR DESCRIPTION
This must be merged with iotauth/sst-c-api#41.

### Enable password options
This PR updates the secure file system manager to get the password of the secure database as an input of the executable, using the `-p` or `--password` options.
This is for automated integration tests for the IPFS tests, especially the `secure_entity_uploader/downloader`.
To do this, the `secure_file_system_manger.py` needed to be refactored, adding a `main()` function to use `ArgumentParser`. The logic itself is the same.

### Port number fix
This PR also updates the port number of the secure file system manager from 21100 to 22100, for consistency with the file system manager (the insecure one).

### Change crypto-related library.
I changed the crypto-related library from using `cryptography` to `pycryptodome`, due to RSA padding changes in `6e8a146a93ef53fb7cbc29ae9515c644848645d2`.

This library requires `pip3 install pycryptodome`.