### PR TITLE
Docs: add plain_text creation step to file sharing README

### DIFF
--- a/examples/file_sharing/README.md
+++ b/examples/file_sharing/README.md
@@ -59,17 +59,19 @@ See README.md under *examples/* for details.
 
 1. Run `git submodule update --remote` to update the `sst-c-api` submodule.
 
-2. Change directories to `$ROOT/entity/c/examples/ipfs_examples/c` (Move the file for experiment in this directory and change the file name to "plain_text")
+2. Create a non-empty test file named `plain_text` in `$ROOT/entity/c/examples/ipfs_examples/` (run the following command from this directory): `echo "hello from uploader" > plain_text`
 
-3. Run `mkdir build && cd build`
+3. Change directories to `$ROOT/entity/c/examples/ipfs_examples/c`
 
-4. Run `cmake ../` to make the Makefile to build.
+4. Run `mkdir build && cd build`
 
-5. Run `make` 
+5. Run `cmake ../` to make the Makefile to build.
 
-6. Run `./entity_uploader ../../uploader.config ../../plain_text ../../addReader.txt` in a separate terminal, to execute net1.uploader.
+6. Run `make` 
 
-7. Run `./entity_downloader ../../downloader.config`, to execute net1.downloader.
+7. Run `./entity_uploader ../../uploader.config ../../plain_text ../../addReader.txt` in a separate terminal, to execute net1.uploader.
+
+8. Run `./entity_downloader ../../downloader.config`, to execute net1.downloader.
 
 # Security for File System Manager
 ---

--- a/examples/file_sharing/README.md
+++ b/examples/file_sharing/README.md
@@ -59,9 +59,9 @@ See README.md under *examples/* for details.
 
 1. Run `git submodule update --remote` to update the `sst-c-api` submodule.
 
-2. Create a non-empty test file named `plain_text` in `$ROOT/entity/c/examples/ipfs_examples/` (run the following command from this directory): `echo "hello from uploader" > plain_text`
-
-3. Change directories to `$ROOT/entity/c/examples/ipfs_examples/c`
+2. Change directories to `$ROOT/entity/c/examples/ipfs_examples/c`
+ 
+3. Create a non-empty test file named `plain_text` in `$ROOT/entity/c/examples/ipfs_examples/` (e.g., by running the following command from this directory): `echo "hello from uploader" > plain_text`
 
 4. Run `mkdir build && cd build`
 

--- a/examples/file_sharing/README.md
+++ b/examples/file_sharing/README.md
@@ -59,19 +59,21 @@ See README.md under *examples/* for details.
 
 1. Run `git submodule update --remote` to update the `sst-c-api` submodule.
 
-2. Change directories to `$ROOT/entity/c/examples/ipfs_examples/c`
+2. Change directories to `$ROOT/entity/c/examples/ipfs_examples/`
  
 3. Create a non-empty test file named `plain_text` in `$ROOT/entity/c/examples/ipfs_examples/` (e.g., by running the following command from this directory): `echo "hello from uploader" > plain_text`
 
-4. Run `mkdir build && cd build`
+4. Change directories to `$ROOT/entity/c/examples/ipfs_examples/c`
 
-5. Run `cmake ../` to make the Makefile to build.
+5. Run `mkdir build && cd build`
 
-6. Run `make` 
+6. Run `cmake ../` to make the Makefile to build.
 
-7. Run `./entity_uploader ../../uploader.config ../../plain_text ../../addReader.txt` in a separate terminal, to execute net1.uploader.
+7. Run `make` 
 
-8. Run `./entity_downloader ../../downloader.config`, to execute net1.downloader.
+8. Run `./entity_uploader ../../uploader.config ../../plain_text ../../addReader.txt` in a separate terminal, to execute net1.uploader.
+
+9. Run `./entity_downloader ../../downloader.config`, to execute net1.downloader.
 
 # Security for File System Manager
 ---


### PR DESCRIPTION
While running the file sharing example end-to-end, the uploader failed because the expected plain_text file was not created, even though it is required by the command (../../plain_text). This PR updates the README to explicitly add the plain_text creation step before building and running the example. The example was verified by successfully re-running it after this change.