### PR TITLE
Handle Auth disconnection in file managers and enable address reuse for fast debugging.

### DIFF
--- a/examples/file_sharing/file_system_manager.py
+++ b/examples/file_sharing/file_system_manager.py
@@ -87,6 +87,7 @@ port = 22100
 host, port = '127.0.0.1', port
 
 lsock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+lsock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 lsock.bind((host, port))
 lsock.listen()
 print(f"Listening on {(host, port)}")

--- a/examples/file_sharing/secure_file_system_manager.py
+++ b/examples/file_sharing/secure_file_system_manager.py
@@ -94,7 +94,8 @@ def service_connection(key, mask, file_manager_dict, file_metadata_table, distri
             recv_data_from_auth = client_sock.recv(entity_server.READ_BYTES_NUM)
             # Continue the loop if no data received
             if len(recv_data_from_auth) == 0:
-                continue
+                print("Connection to Auth server closed unexpectedly.")
+                break
             # Process the received data to get the session key
             entity_server.get_session_key(recv_data_from_auth, file_manager_dict, client_sock, distribution_key, comm_session_key, nonce_auth)
 
@@ -151,6 +152,7 @@ def main():
         sys.exit(1)
 
     manager_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    manager_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     manager_socket.bind((host, port))
     manager_socket.listen()
     print(f"Listening on {(host, port)}")


### PR DESCRIPTION
1. **Handle Unexpected Auth Server Disconnection**: 
   Updated the secure file system manager to exit the handshake loop (by replacing `continue` with `break`) when the connection to the Authentication Server is closed unexpectedly. This prevents the manager from entering an infinite loop of empty reads, which could cause CI workflows to hang indefinitely, which happened in [here](https://github.com/iotauth/sst-c-api/actions/runs/27437939481/job/81104515166) and reported https://github.com/iotauth/sst-c-api/issues/69.

2. **Enable Socket Address Reuse (`SO_REUSEADDR`)**: 
   Added `SO_REUSEADDR` configuration to socket binding in both `file_system_manager.py` and `secure_file_system_manager.py`. This prevents `OSError: [Errno 48] Address already in use` errors during fast server restarts when the port is in the `TIME_WAIT` state.