### PR TITLE
Run `sst-c-api` tests as part of iotauth CI

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -16,6 +16,11 @@ on:
     branches: [ "main" ]
 
 jobs:
+  sst-c-api-tests:
+    uses: iotauth/sst-c-api/.github/workflows/ci.yml@main
+    with:
+      iotauth-ref: ${{ github.sha }}
+
   integration-test:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Run sst-c-api's unit and integration tests on every iotauth push/PR.

- Calls iotauth/sst-c-api CI via workflow_call
- Passes current iotauth SHA so integration tests run against the triggering commit

Note: merge iotauth/sst-c-api#72 first.

This feature was added because `sst-c-api` has dependencies on `iotauth`, and it cannot be found when only iotauth is changed alone.