### PR TITLE
Add `workflow_call` trigger to allow invocation from `sst-c-api` CI

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -14,6 +14,12 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_call:
+    inputs:
+      sst-c-api-ref:
+        description: 'sst-c-api ref to test (overrides submodule pin)'
+        required: false
+        type: string
 
 jobs:
   sst-c-api-tests:
@@ -29,6 +35,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Check out specific ref of sst-c-api
+        if: ${{ inputs.sst-c-api-ref != '' }}
+        uses: actions/checkout@v4
+        with:
+          repository: iotauth/sst-c-api
+          path: entity/c
+          ref: ${{ inputs.sst-c-api-ref }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4


### PR DESCRIPTION
Allow the entity integration tests to be called from `sst-c-api`'s CI.

- Adds `workflow_call` trigger with optional `sst-c-api-ref` input
- When called from `sst-c-api`, overrides the submodule-pinned `entity/c` with the specified ref so the triggering commit is tested
- Existing push/PR behavior is unchanged

Should be merged ahead of https://github.com/iotauth/sst-c-api/pull/73
