### PR TITLE
CI fix : Fix reusable workflow checkout and separate `sst-c-api` verification

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -22,11 +22,6 @@ on:
         type: string
 
 jobs:
-  sst-c-api-tests:
-    uses: iotauth/sst-c-api/.github/workflows/ci.yml@main
-    with:
-      iotauth-ref: ${{ github.sha }}
-
   integration-test:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -29,7 +29,9 @@ jobs:
       - name: Check out repository with submodules
         uses: actions/checkout@v4
         with:
+          repository: iotauth/iotauth
           submodules: recursive
+          ref: ${{ github.repository == 'iotauth/iotauth' && github.sha || 'main' }}
 
       - name: Check out specific ref of sst-c-api
         if: ${{ inputs.sst-c-api-ref != '' }}

--- a/.github/workflows/sst-c-api-tests.yml
+++ b/.github/workflows/sst-c-api-tests.yml
@@ -1,0 +1,13 @@
+name: sst-c-api Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  sst-c-api-tests:
+    uses: iotauth/sst-c-api/.github/workflows/ci.yml@main
+    with:
+      iotauth-ref: ${{ github.sha }}

--- a/.github/workflows/sst-c-api-tests.yml
+++ b/.github/workflows/sst-c-api-tests.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   sst-c-api-tests:
-    uses: iotauth/sst-c-api/.github/workflows/ci.yml@ci-fix
+    uses: iotauth/sst-c-api/.github/workflows/ci.yml@main
     with:
       iotauth-ref: ${{ github.sha }}

--- a/.github/workflows/sst-c-api-tests.yml
+++ b/.github/workflows/sst-c-api-tests.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   sst-c-api-tests:
-    uses: iotauth/sst-c-api/.github/workflows/ci.yml@main
+    uses: iotauth/sst-c-api/.github/workflows/ci.yml@ci-fix
     with:
       iotauth-ref: ${{ github.sha }}


### PR DESCRIPTION
This PR resolves CI issues in reusable workflow calls and improves workflow organization:
- **Fix called workflow checkout**: Explicitly configured `repository: iotauth/iotauth` and `ref` inside `integration-test.yml`. This prevents it from checking out `sst-c-api` instead of `iotauth` when called as a reusable workflow from downstream.
- **Split integration workflow**: Moved `sst-c-api-tests` job into a separate workflow file `sst-c-api-tests.yml` to separate concerns and eliminate static parsing loops.
- **Update submodule**: Updated the `sst-c-api` submodule pin to the latest commit containing workflow fixes.