### PR TITLE
Fix: CA certificate missing BasicConstraints (CA:true) extension

### DIFF
--- a/auth/credentials/README.md
+++ b/auth/credentials/README.md
@@ -15,6 +15,15 @@
 
 (Separated genrsa and req processes, no more need for password)
 
+### ⚠️ Note on CA certificate extensions
+---
+`-extensions v3_ca` alone doesn't guarantee `[v3_ca]` is defined — it depends on the system's default OpenSSL config, which varies by environment. If missing, `CACert.pem` lacks `BasicConstraints: CA:true`, causing Auth-to-Auth TLS handshakes to fail (Java's PKIX validator rejects non-CA trust anchors).
+
+Fix: added `ca.cnf` defining `[v3_ca]` explicitly, and pass it via `-extfile` so the extension is always applied regardless of environment.
+
+`generateCACredentials.sh` now explicitly passes `-extfile ca.cnf` to avoid this environment dependency:
+`openssl x509 -req -in CAReq.pem -sha256 -extensions v3_ca -extfile ca.cnf -signkey CAKey.pem -out CACert.pem -days 730`
+
 ### To check subjet, issuer, validity period of a certificate
 ---
 openssl x509 -noout -startdate -enddate -subject -issuer -in CACert.pem 

--- a/auth/credentials/ca.cnf
+++ b/auth/credentials/ca.cnf
@@ -1,0 +1,5 @@
+[ v3_ca ]
+basicConstraints = critical, CA:true
+keyUsage = critical, keyCertSign, cRLSign
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer:always

--- a/auth/credentials/generateCACredentials.sh
+++ b/auth/credentials/generateCACredentials.sh
@@ -18,6 +18,9 @@ mkdir -p $CA_DIR
 
 openssl genrsa -passout pass:$CA_PASSWORD -out $CA_DIR/CAKey.pem -aes128 2048
 openssl req -passin pass:$CA_PASSWORD -passout pass:$CA_PASSWORD -new -key $CA_DIR/CAKey.pem -sha256 -out $CA_DIR/CAReq.pem -subj "/C=US/ST=CA/L=Berkeley/O=EECS/OU=CertificateAuthority/CN=iotauth.org"
-openssl x509 -passin pass:$CA_PASSWORD -req -in $CA_DIR/CAReq.pem -sha256 -extensions v3_ca -signkey $CA_DIR/CAKey.pem -out $CA_DIR/CACert.pem -days $VAL_DAYS
+#openssl x509 -passin pass:$CA_PASSWORD -req -in $CA_DIR/CAReq.pem -sha256 -extensions v3_ca -signkey $CA_DIR/CAKey.pem -out $CA_DIR/CACert.pem -days $VAL_DAYS
+openssl x509 -passin pass:$CA_PASSWORD -req -in $CA_DIR/CAReq.pem -sha256 \
+  -extensions v3_ca -extfile ca.cnf \
+  -signkey $CA_DIR/CAKey.pem -out $CA_DIR/CACert.pem -days $VAL_DAYS
 
 rm $CA_DIR/CAReq.pem

--- a/examples/configs/remote_server.graph
+++ b/examples/configs/remote_server.graph
@@ -2,7 +2,7 @@
 	"authList": [
 		{
 			"id": 101,
-			"entityHost": "localhost",
+			"entityHost": "10.218.100.78",
 			"authHost": "10.218.100.78",
 			"tcpPort": 21900,
 			"udpPort": 21902,

--- a/examples/configs/remote_server.graph
+++ b/examples/configs/remote_server.graph
@@ -1,0 +1,140 @@
+{
+	"authList": [
+		{
+			"id": 101,
+			"entityHost": "localhost",
+			"authHost": "10.218.100.78",
+			"tcpPort": 21900,
+			"udpPort": 21902,
+			"authPort": 21901,
+			"callbackPort": 21903,
+			"dbProtectionMethod": 1,
+			"backupEnabled": false,
+			"contextualCallbackEnabled": true
+		}
+	],
+	"authTrusts": [],
+	"assignments": {
+		"net1.client": 101,
+		"net1.server": 101,
+		"net1.adminClient": 101,
+		"net1.adminServer": 101
+	},
+	"entityList": [
+		{
+			"group": "Clients",
+			"name": "net1.client",
+			"distProtocol": "TCP",
+			"usePermanentDistKey": false,
+			"distKeyValidityPeriod": "1*hour",
+			"maxSessionKeysPerRequest": 5,
+			"netName": "net1",
+			"credentialPrefix": "Net1.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"backupToAuthIds": [],
+			"targetServerInfoList": [
+				{"name": "net1.server", "host": "10.218.100.78", "port": 21100, "group": "Servers"}
+			],
+			"contextList": []
+		},
+		{
+			"group": "Servers",
+			"name": "net1.server",
+			"port": 21100,
+			"distProtocol": "TCP",
+			"usePermanentDistKey": false,
+			"distKeyValidityPeriod": "1*hour",
+			"maxSessionKeysPerRequest": 1,
+			"netName": "net1",
+			"credentialPrefix": "Net1.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"host": "10.218.100.78",
+			"backupToAuthIds": []
+		},
+		{
+			"group": "AdminClients",
+			"name": "net1.adminClient",
+			"distProtocol": "TCP",
+			"usePermanentDistKey": false,
+			"distKeyValidityPeriod": "1*hour",
+			"maxSessionKeysPerRequest": 5,
+			"netName": "net1",
+			"credentialPrefix": "Net1.AdminClient",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"backupToAuthIds": [],
+			"targetServerInfoList": [
+				{"name": "net1.adminServer", "host": "localhost", "port": 21200, "group": "AdminServers"}
+			]
+		},
+		{
+			"group": "AdminServers",
+			"name": "net1.adminServer",
+			"port": 21200,
+			"distProtocol": "TCP",
+			"usePermanentDistKey": false,
+			"distKeyValidityPeriod": "1*hour",
+			"maxSessionKeysPerRequest": 1,
+			"netName": "net1",
+			"credentialPrefix": "Net1.AdminServer",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"host": "localhost",
+			"backupToAuthIds": []
+		}
+	],
+	"filesharingLists": [],
+	"privilegeList": [],
+	"commPolicies": [
+		{
+			"RequestingGroup": "Clients",
+			"TargetType": "Group",
+			"Target": "Servers",
+			"MaxNumSessionKeyOwners": 2,
+			"SessionCryptoSpec": "AES-128-CBC:SHA256",
+			"AbsoluteValidity": "1*day",
+			"RelativeValidity": "2*hour",
+			"Expiration": "Infinity",
+			"IsDelegated": 0,
+			"Context": null
+		},
+		{
+			"RequestingGroup": "AdminClients",
+			"TargetType": "Group",
+			"Target": "AdminServers",
+			"MaxNumSessionKeyOwners": 2,
+			"SessionCryptoSpec": "AES-128-CBC:SHA256",
+			"AbsoluteValidity": "1*day",
+			"RelativeValidity": "2*hour",
+			"Expiration": "Infinity",
+			"IsDelegated": 0,
+			"Context": null
+		}
+	]
+}

--- a/examples/configs/remote_server.graph
+++ b/examples/configs/remote_server.graph
@@ -2,8 +2,8 @@
 	"authList": [
 		{
 			"id": 101,
-			"entityHost": "10.218.100.78",
-			"authHost": "10.218.100.78",
+			"entityHost": "localhost",
+			"authHost": "localhost",
 			"tcpPort": 21900,
 			"udpPort": 21902,
 			"authPort": 21901,
@@ -58,7 +58,7 @@
 			},
 			"backupToAuthIds": [],
 			"targetServerInfoList": [
-				{"name": "net1.server", "host": "10.218.100.78", "port": 21100, "group": "Servers"}
+				{"name": "net2.server", "host": "localhost", "port": 22100, "group": "Servers"}
 			],
 			"contextList": []
 		},
@@ -80,7 +80,7 @@
                 "cipher": "AES-128-CBC",
                 "mac": "SHA256"
             },
-            "host": "10.218.100.78",
+            "host": "localhost",
             "backupToAuthIds": []
         },
 		{

--- a/examples/configs/remote_server.graph
+++ b/examples/configs/remote_server.graph
@@ -11,12 +11,30 @@
 			"dbProtectionMethod": 1,
 			"backupEnabled": false,
 			"contextualCallbackEnabled": true
-		}
+		},
+        {
+            "id": 102,
+            "entityHost": "localhost",
+            "authHost": "localhost",
+            "tcpPort": 22900,
+            "udpPort": 22902,
+            "authPort": 22901,
+            "callbackPort": 22903,
+            "dbProtectionMethod": 1,
+            "backupEnabled": false,
+            "contextualCallbackEnabled": true
+        }
 	],
-	"authTrusts": [],
+	"authTrusts": [
+        {
+            "id1": 101,
+            "id2": 102
+        }
+    ],
 	"assignments": {
 		"net1.client": 101,
 		"net1.server": 101,
+		"net2.server": 102,
 		"net1.adminClient": 101,
 		"net1.adminServer": 101
 	},
@@ -45,15 +63,36 @@
 			"contextList": []
 		},
 		{
+            "group": "Servers",
+            "name": "net1.server",
+            "port": 21100,
+            "distProtocol": "TCP",
+            "usePermanentDistKey": false,
+            "distKeyValidityPeriod": "1*hour",
+            "maxSessionKeysPerRequest": 1,
+            "netName": "net1",
+            "credentialPrefix": "Net1.Server",
+            "distributionCryptoSpec": {
+                "cipher": "AES-128-CBC",
+                "mac": "SHA256"
+            },
+            "sessionCryptoSpec": {
+                "cipher": "AES-128-CBC",
+                "mac": "SHA256"
+            },
+            "host": "10.218.100.78",
+            "backupToAuthIds": []
+        },
+		{
 			"group": "Servers",
-			"name": "net1.server",
-			"port": 21100,
+			"name": "net2.server",
+			"port": 22100,
 			"distProtocol": "TCP",
 			"usePermanentDistKey": false,
 			"distKeyValidityPeriod": "1*hour",
 			"maxSessionKeysPerRequest": 1,
-			"netName": "net1",
-			"credentialPrefix": "Net1.Server",
+			"netName": "net2",
+			"credentialPrefix": "Net2.Server",
 			"distributionCryptoSpec": {
 				"cipher": "AES-128-CBC",
 				"mac": "SHA256"
@@ -62,7 +101,7 @@
 				"cipher": "AES-128-CBC",
 				"mac": "SHA256"
 			},
-			"host": "10.218.100.78",
+			"host": "localhost",
 			"backupToAuthIds": []
 		},
 		{


### PR DESCRIPTION
## Problem
`generateCACredentials.sh` signed the CA certificate with `-extensions v3_ca`, but did not pass `-extfile`, so OpenSSL fell back to the system default config to resolve the `[v3_ca]` section. In some environments, this section isn't found, so the `BasicConstraints` extension is silently omitted from `CACert.pem`.
This caused Auth-to-Auth TLS handshakes to fail with:
`sun.security.validator.ValidatorException: TrustAnchor with subject "CN=iotauth.org, OU=CertificateAuthority, O=EECS, L=Berkeley, ST=CA, C=US" is not a CA certificate`

## Fix
- Added `credentials/ca.cnf`, defining `[v3_ca]` with `basicConstraints = critical, CA:true` and related extensions.
  Placed outside `ca/` since `generateAll` wipes that directory.
- Updated `generateCACredentials.sh` to pass `-extfile ca.cnf` explicitly,  so the extension no longer depends on the system's default OpenSSL config.

## Testing
- Ran `./generateAll` and verified with `keytool -printcert -file ca/CACert.pem` that `BasicConstraints:[CA:true]` is now present.
- Confirmed Auth-to-Auth TLS handshake succeeds (no more `certificate_unknown` error).